### PR TITLE
Jhbate/fix error on reset

### DIFF
--- a/api/forgot.go
+++ b/api/forgot.go
@@ -83,7 +83,7 @@ func (a *Api) passwordReset(res http.ResponseWriter, req *http.Request, vars map
 //find the reset confirmation if it exists and hasn't expired
 func (a *Api) findResetConfirmation(conf *models.Confirmation, res http.ResponseWriter) (*models.Confirmation, error) {
 
-	log.Printf("finding reset [%v]", conf)
+	log.Printf("findResetConfirmation: finding [%v]", conf)
 	if resetCnf := a.findExistingConfirmation(conf, res); resetCnf != nil {
 
 		expires := resetCnf.Created.Add(time.Duration(a.Config.ResetTimeoutDays) * 24 * time.Hour)

--- a/api/forgot.go
+++ b/api/forgot.go
@@ -81,19 +81,29 @@ func (a *Api) passwordReset(res http.ResponseWriter, req *http.Request, vars map
 }
 
 //find the reset confirmation if it exists and hasn't expired
-func (a *Api) findResetConfirmation(conf *models.Confirmation, res http.ResponseWriter) (*models.Confirmation, error) {
+func (a *Api) findResetConfirmation(conf *models.Confirmation, res http.ResponseWriter) *models.Confirmation {
 
 	log.Printf("findResetConfirmation: finding [%v]", conf)
-	if resetCnf := a.findExistingConfirmation(conf, res); resetCnf != nil {
+	if found, err := a.findExistingConfirmation(conf, res); err != nil {
+		log.Printf("findResetConfirmation: error [%s]\n", err.Error())
+		a.sendModelAsResWithStatus(res, err, http.StatusInternalServerError)
+		return nil
+	} else if found != nil {
 
-		expires := resetCnf.Created.Add(time.Duration(a.Config.ResetTimeoutDays) * 24 * time.Hour)
+		expires := found.Created.Add(time.Duration(a.Config.ResetTimeoutDays) * 24 * time.Hour)
 
 		if time.Now().Before(expires) {
-			return resetCnf, nil
+			return found
 		}
-		return nil, &status.StatusError{status.NewStatus(http.StatusUnauthorized, STATUS_RESET_EXPIRED)}
+		statusErr := &status.StatusError{status.NewStatus(http.StatusUnauthorized, STATUS_RESET_EXPIRED)}
+		log.Printf("findResetConfirmation: expired [%s]\n", statusErr.Error())
+		a.sendModelAsResWithStatus(res, statusErr, http.StatusNotFound)
+		return nil
 	}
-	return nil, nil
+	statusErr := &status.StatusError{status.NewStatus(http.StatusNotFound, STATUS_RESET_NOT_FOUND)}
+	log.Printf("findResetConfirmation: not found [%s]\n", statusErr.Error())
+	a.sendModelAsResWithStatus(res, statusErr, http.StatusNotFound)
+	return nil
 }
 
 //Accept the password change
@@ -123,7 +133,7 @@ func (a *Api) acceptPassword(res http.ResponseWriter, req *http.Request, vars ma
 
 	resetCnf := &models.Confirmation{Key: rb.Key, Email: rb.Email, Type: models.TypePasswordReset}
 
-	if conf, err := a.findResetConfirmation(resetCnf, res); err == nil && conf != nil {
+	if conf := a.findResetConfirmation(resetCnf, res); conf != nil {
 
 		token := a.sl.TokenProvide()
 
@@ -147,13 +157,6 @@ func (a *Api) acceptPassword(res http.ResponseWriter, req *http.Request, vars ma
 				return
 			}
 		}
-
-	} else if err != nil {
-		//there was an error
-		log.Printf("acceptPassword: finding reset confirmation %v\n", err)
-		statusErr := &status.StatusError{status.NewStatus(http.StatusBadRequest, STATUS_RESET_ERROR)}
-		a.sendModelAsResWithStatus(res, statusErr, http.StatusBadRequest)
-		return
 	}
 	return
 }

--- a/api/hydrophoneApi.go
+++ b/api/hydrophoneApi.go
@@ -144,10 +144,11 @@ func (a *Api) GetStatus(res http.ResponseWriter, req *http.Request) {
 	return
 }
 
-//Save this confirmation or write and error if it all goes wrong
+//Save this confirmation or
+//write an error if it all goes wrong
 func (a *Api) addOrUpdateConfirmation(conf *models.Confirmation, res http.ResponseWriter) bool {
 	if err := a.Store.UpsertConfirmation(conf); err != nil {
-		log.Println("Error saving the confirmation ", err)
+		log.Printf("Error saving the confirmation [%v]", err)
 		statusErr := &status.StatusError{status.NewStatus(http.StatusInternalServerError, STATUS_ERR_SAVING_CONFIRMATION)}
 		a.sendModelAsResWithStatus(res, statusErr, http.StatusInternalServerError)
 		return false
@@ -155,23 +156,20 @@ func (a *Api) addOrUpdateConfirmation(conf *models.Confirmation, res http.Respon
 	return true
 }
 
-//Find this confirmation, write error if fails or write no-content if it doesn't exist
-func (a *Api) findExistingConfirmation(conf *models.Confirmation, res http.ResponseWriter) *models.Confirmation {
+//Find this confirmation
+//write error if it fails
+func (a *Api) findExistingConfirmation(conf *models.Confirmation, res http.ResponseWriter) (*models.Confirmation, error) {
 	if found, err := a.Store.FindConfirmation(conf); err != nil {
-		log.Println("Error finding the confirmation ", err)
+		log.Printf("findExistingConfirmation: [%v]", err)
 		statusErr := &status.StatusError{status.NewStatus(http.StatusInternalServerError, STATUS_ERR_FINDING_CONFIRMATION)}
-		a.sendModelAsResWithStatus(res, statusErr, http.StatusInternalServerError)
-		return nil
-	} else if found == nil {
-		statusErr := &status.StatusError{status.NewStatus(http.StatusNotFound, STATUS_NOT_FOUND)}
-		a.sendModelAsResWithStatus(res, statusErr, http.StatusNotFound)
-		return nil
+		return nil, statusErr
 	} else {
-		return found
+		return found, nil
 	}
 }
 
-//Find this confirmation, write error if fails or write no-content if it doesn't exist
+//Find these confirmations
+//write error if fails or write no-content if it doesn't exist
 func (a *Api) checkFoundConfirmations(res http.ResponseWriter, results []*models.Confirmation, err error) []*models.Confirmation {
 	if err != nil {
 		log.Println("Error finding confirmations ", err)
@@ -179,8 +177,8 @@ func (a *Api) checkFoundConfirmations(res http.ResponseWriter, results []*models
 		a.sendModelAsResWithStatus(res, statusErr, http.StatusInternalServerError)
 		return nil
 	} else if results == nil || len(results) == 0 {
-		log.Printf("No confirmations were found")
 		statusErr := &status.StatusError{status.NewStatus(http.StatusNotFound, STATUS_NOT_FOUND)}
+		log.Printf("No confirmations were found [%s]", statusErr.Error())
 		a.sendModelAsResWithStatus(res, statusErr, http.StatusNotFound)
 		return nil
 	} else {

--- a/clients/mongoStoreClient.go
+++ b/clients/mongoStoreClient.go
@@ -77,7 +77,8 @@ func (d MongoStoreClient) FindConfirmation(confirmation *models.Confirmation) (r
 		query["userId"] = confirmation.UserId
 	}
 
-	if err = d.confirmationsC.Find(query).One(&result); err != nil {
+	if err = d.confirmationsC.Find(query).One(&result); err != nil && err != mgo.ErrNotFound {
+		log.Printf("FindConfirmation: something bad happened [%v]", err)
 		return result, err
 	}
 
@@ -108,7 +109,8 @@ func (d MongoStoreClient) FindConfirmations(confirmation *models.Confirmation, s
 		query["status"] = bson.M{"$in": statuses}
 	}
 
-	if err = d.confirmationsC.Find(query).Sort("created").All(&results); err != nil {
+	if err = d.confirmationsC.Find(query).Sort("created").All(&results); err != nil && err != mgo.ErrNotFound {
+		log.Printf("FindConfirmations: something bad happened [%v]", err)
 		return results, err
 	}
 	return results, nil

--- a/clients/mongoStoreClient_test.go
+++ b/clients/mongoStoreClient_test.go
@@ -20,6 +20,7 @@ func TestMongoStoreConfirmationOperations(t *testing.T) {
 	var (
 		config          Config
 		confirmation, _ = models.NewConfirmation(models.TypePasswordReset, "123.456")
+		doesNotExist, _ = models.NewConfirmation(models.TypePasswordReset, "123.456")
 	)
 
 	if jsonConfig, err := ioutil.ReadFile("../config/server.json"); err == nil {
@@ -42,6 +43,7 @@ func TestMongoStoreConfirmationOperations(t *testing.T) {
 		}
 
 		//The basics
+		//+++++++++++++++++++++++++++
 		if err := mc.UpsertConfirmation(confirmation); err != nil {
 			t.Fatalf("we could not save the con %v", err)
 		}
@@ -52,6 +54,13 @@ func TestMongoStoreConfirmationOperations(t *testing.T) {
 			}
 		} else {
 			t.Fatalf("no confirmation was returned when it should have been - err[%v]", err)
+		}
+
+		//when the conf doesn't exist
+		if found, err := mc.FindConfirmation(doesNotExist); err == nil && found != nil {
+			t.Fatalf("there should have been no confirmation found [%v]", found)
+		} else if err != nil {
+			t.Fatalf("and error was returned when it should not have been err[%v]", err)
 		}
 
 		if err := mc.RemoveConfirmation(confirmation); err != nil {


### PR DESCRIPTION
@kentquirk this change fixes the failure you noticed in pltform-client

### of note:

- when no record is found mongo returns an error, it is a  mgo.ErrNotFound, I didn't expect this. I have now updated the hydrophone mongo tests to provide functionality that I had intended

- I also cleaned up some of the logging so that it is easier to understand and debug
```
2015/01/13 16:13:47 findResetConfirmation: finding [&{i-dont-know password_reset nan@nan.org  [] 0001-01-01 00:00:00 +0000 UTC   0001-01-01 00:00:00 +0000 UTC}]
2015/01/13 16:13:47 findResetConfirmation: not found [404 No matching reset confirmation was found]
```

- all tests for hydrophone passing and I have also confirmed again platform-client.