### PR TITLE
Cleanup and use session copy pattern

### DIFF
--- a/Comedeps
+++ b/Comedeps
@@ -2,4 +2,4 @@ labix.org/v2/mgo bzr https://launchpad.net/mgo/v2 287
 launchpad.net/gocheck git https://github.com/go-check/check.git 91ae5f88a67b14891cfd43895b01164f6c120420
 github.com/gorilla/mux git https://github.com/gorilla/mux.git 14cafe28513321476c73967a5a4f3454b6129c46
 github.com/gorilla/context git https://github.com/gorilla/context.git 14f550f51af52180c2eefed15e5fd18d63c0a64a
-github.com/tidepool-org/go-common git https://github.com/tidepool-org/go-common.git cf6e8347ab23a2b719558c300e774c42dab0690f
+github.com/tidepool-org/go-common git https://github.com/tidepool-org/go-common.git e2c617d2e4789150b0f443838ed961ab4f50de88

--- a/api/hydrophoneApi.go
+++ b/api/hydrophoneApi.go
@@ -129,11 +129,6 @@ func (h varsHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	h(res, req, vars)
 }
 
-func (a *Api) Dummy(res http.ResponseWriter, req *http.Request, vars map[string]string) {
-	log.Printf("dummy() ignored request %s %s", req.Method, req.URL)
-	res.WriteHeader(http.StatusOK)
-}
-
 func (a *Api) GetStatus(res http.ResponseWriter, req *http.Request) {
 	if err := a.Store.Ping(); err != nil {
 		log.Printf("Error getting status [%v]", err)

--- a/api/hydrophoneApi_test.go
+++ b/api/hydrophoneApi_test.go
@@ -33,7 +33,7 @@ var (
 		Templates: &models.TemplateConfig{
 			PasswordReset:  `{{define "reset_test"}} {{ .Email }} {{ .Key }} {{end}}{{template "reset_test" .}}`,
 			CareteamInvite: `{{define "invite_test"}} {{ .CareteamName }} {{ .Key }} {{end}}{{template "invite_test" .}}`,
-			Confirmation:   `{{define "confirm_test"}} {{ .UserId }} {{ .Key }} {{end}}{{template "confirm_test" .}}`,
+			Signup:         `{{define "confirm_test"}} {{ .UserId }} {{ .Key }} {{end}}{{template "confirm_test" .}}`,
 		},
 		InviteTimeoutDays: 7,
 		ResetTimeoutDays:  7,

--- a/api/signup.go
+++ b/api/signup.go
@@ -188,7 +188,7 @@ func (a *Api) resendSignUp(res http.ResponseWriter, req *http.Request, vars map[
 		if a.createAndSendNotfication(found, emailContent) {
 			a.logMetricAsServer("signup confirmation re-sent")
 		} else {
-			a.logMetric("signup confirmation failed to be sent", req)
+			a.logMetricAsServer("signup confirmation failed to be sent")
 			log.Print("resendSignUp: Something happened trying to resend a signup email")
 		}
 	}
@@ -227,7 +227,7 @@ func (a *Api) acceptSignUp(res http.ResponseWriter, req *http.Request, vars map[
 
 		found.UpdateStatus(models.StatusCompleted)
 		if a.addOrUpdateConfirmation(found, res) {
-			a.logMetric("accept signup", req)
+			a.logMetricAsServer("accept signup")
 			res.WriteHeader(http.StatusOK)
 			return
 		}

--- a/api/signup.go
+++ b/api/signup.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"./../models"
+	"github.com/tidepool-org/go-common/clients/shoreline"
 	"github.com/tidepool-org/go-common/clients/status"
 )
 
@@ -140,7 +141,7 @@ func (a *Api) sendSignUp(res http.ResponseWriter, req *http.Request, vars map[st
 				return
 			}
 
-			newSignUp, _ := models.NewConfirmation(models.TypeConfirmation, "")
+			newSignUp, _ := models.NewConfirmation(models.TypeSignUp, "")
 			newSignUp.UserId = usrDetails.UserID
 			newSignUp.Email = usrDetails.Emails[0]
 
@@ -170,33 +171,29 @@ func (a *Api) sendSignUp(res http.ResponseWriter, req *http.Request, vars map[st
 //offer to resend the confirmation email.
 //
 // status: 200
-// status: 401 STATUS_NO_TOKEN
 // status: 404 STATUS_SIGNUP_EXPIRED
 func (a *Api) resendSignUp(res http.ResponseWriter, req *http.Request, vars map[string]string) {
 
-	if a.checkToken(res, req) {
-		userId := vars["userid"]
+	userId := vars["userid"]
 
-		toFind := &models.Confirmation{UserId: userId}
+	toFind := &models.Confirmation{UserId: userId}
 
-		if found := a.findAndValidateSignUp(toFind, res); found != nil {
+	if found := a.findAndValidateSignUp(toFind, res); found != nil {
 
-			emailContent := &signUpEmailContent{
-				Key:   found.Key,
-				Email: found.Email,
-			}
-
-			if a.createAndSendNotfication(found, emailContent) {
-				a.logMetricAsServer("signup confirmation re-sent")
-			} else {
-				a.logMetric("signup confirmation failed to be sent", req)
-				log.Print("resendSignUp: Something happened trying to resend a signup email")
-			}
+		emailContent := &signUpEmailContent{
+			Key:   found.Key,
+			Email: found.Email,
 		}
-		//always return StatusOK so we don't leak details
-		res.WriteHeader(http.StatusOK)
-		return
+
+		if a.createAndSendNotfication(found, emailContent) {
+			a.logMetricAsServer("signup confirmation re-sent")
+		} else {
+			a.logMetric("signup confirmation failed to be sent", req)
+			log.Print("resendSignUp: Something happened trying to resend a signup email")
+		}
 	}
+	//always return StatusOK so we don't leak details
+	res.WriteHeader(http.StatusOK)
 	return
 }
 
@@ -207,32 +204,35 @@ func (a *Api) resendSignUp(res http.ResponseWriter, req *http.Request, vars map[
 // status: 200
 // status: 400 STATUS_SIGNUP_NO_ID_OR_CONF
 func (a *Api) acceptSignUp(res http.ResponseWriter, req *http.Request, vars map[string]string) {
-	if a.checkToken(res, req) {
 
-		userId := vars["userid"]
-		confirmationId := vars["confirmationid"]
+	userId := vars["userid"]
+	confirmationId := vars["confirmationid"]
 
-		if userId == "" || confirmationId == "" {
-			log.Printf("acceptSignUp %s", STATUS_SIGNUP_NO_ID_OR_CONF)
-			a.sendModelAsResWithStatus(res, status.NewStatus(http.StatusBadRequest, STATUS_SIGNUP_NO_ID_OR_CONF), http.StatusBadRequest)
+	if userId == "" || confirmationId == "" {
+		log.Printf("acceptSignUp %s", STATUS_SIGNUP_NO_ID_OR_CONF)
+		a.sendModelAsResWithStatus(res, status.NewStatus(http.StatusBadRequest, STATUS_SIGNUP_NO_ID_OR_CONF), http.StatusBadRequest)
+		return
+	}
+
+	toFind := &models.Confirmation{UserId: userId, Key: confirmationId}
+
+	if found := a.findAndValidateSignUp(toFind, res); found != nil {
+
+		updates := shoreline.UserUpdate{UserData: shoreline.UserData{UserID: userId}, Authenticated: true}
+		if err := a.sl.UpdateUser(updates, a.sl.TokenProvide()); err != nil {
+			log.Printf("acceptSignUp  error trying to update user to be authenticated [%s]", err.Error())
+			res.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
-		toFind := &models.Confirmation{UserId: userId, Key: confirmationId}
-
-		if found := a.findAndValidateSignUp(toFind, res); found != nil {
-			/*TODO: the actual update to set the authenticated flag
-			updates := shoreline.UserUpdate{UserID: userId, Authenticated: true}
-			err := a.sl.UpdateUser(updates, a.sl.TokenProvide())
-			*/
-			found.UpdateStatus(models.StatusCompleted)
-			if a.addOrUpdateConfirmation(found, res) {
-				a.logMetric("accept signup", req)
-				res.WriteHeader(http.StatusOK)
-				return
-			}
+		found.UpdateStatus(models.StatusCompleted)
+		if a.addOrUpdateConfirmation(found, res) {
+			a.logMetric("accept signup", req)
+			res.WriteHeader(http.StatusOK)
+			return
 		}
 	}
+
 	return
 }
 

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -46,34 +46,19 @@ func TestSignupResponds(t *testing.T) {
 			// can't resend a signup if you didn't send it
 			method:   "POST",
 			url:      "/resend/signup",
-			token:    TOKEN_FOR_UID1,
 			respCode: 404,
 		},
 		{
-			// no token is no good
+			// no token is all good
 			method:   "POST",
 			url:      "/resend/signup/UID",
-			respCode: 401,
-		},
-		{
-			// but you can resend a valid one
-			method:   "POST",
-			url:      "/resend/signup/UID",
-			token:    TOKEN_FOR_UID1,
 			respCode: 200,
-		},
-		{
-			// no token is no good
-			method:   "PUT",
-			url:      "/accept/signup/UID2/UID",
-			respCode: 401,
 		},
 		{
 			// you can't accept an invitation you didn't get
 			returnNone: true,
 			method:     "PUT",
 			url:        "/accept/signup/UID2/UIDBad",
-			token:      TOKEN_FOR_UID2,
 			respCode:   404,
 		},
 		{
@@ -81,14 +66,12 @@ func TestSignupResponds(t *testing.T) {
 			returnNone: true,
 			method:     "PUT",
 			url:        "/accept/signup/UID2/UID",
-			token:      TOKEN_FOR_UID2,
 			respCode:   404,
 		},
 		{
 			// all good
 			method:   "PUT",
-			url:      "/accept/signup/UID2/UIDBad",
-			token:    TOKEN_FOR_UID2,
+			url:      "/accept/signup/UID2/UID",
 			respCode: 200,
 		},
 		{

--- a/clients/mongoStoreClient_test.go
+++ b/clients/mongoStoreClient_test.go
@@ -36,9 +36,12 @@ func TestMongoStoreConfirmationOperations(t *testing.T) {
 		 */
 
 		//drop it like its hot
-		mc.confirmationsC.DropCollection()
+		cpy := mc.session.Copy()
+		defer cpy.Close()
 
-		if err := mc.confirmationsC.Create(&mgo.CollectionInfo{}); err != nil {
+		mgoConfirmationsCollection(cpy).DropCollection()
+
+		if err := mgoConfirmationsCollection(cpy).Create(&mgo.CollectionInfo{}); err != nil {
 			t.Fatalf("We couldn't created the users collection for these tests ", err)
 		}
 

--- a/clients/mongoStoreClient_test.go
+++ b/clients/mongoStoreClient_test.go
@@ -1,146 +1,131 @@
 package clients
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"testing"
 
+	"github.com/tidepool-org/go-common/clients/mongo"
 	"labix.org/v2/mgo"
 
 	"./../models"
-	"github.com/tidepool-org/go-common/clients/mongo"
 )
 
 func TestMongoStoreConfirmationOperations(t *testing.T) {
 
-	type Config struct {
-		Mongo *mongo.Config `json:"mongo"`
-	}
-
 	var (
-		config          Config
 		confirmation, _ = models.NewConfirmation(models.TypePasswordReset, "123.456")
 		doesNotExist, _ = models.NewConfirmation(models.TypePasswordReset, "123.456")
 	)
 
-	if jsonConfig, err := ioutil.ReadFile("../config/server.json"); err == nil {
+	testingConfig := &mongo.Config{ConnectionString: "mongodb://localhost/hydrophone_test"}
 
-		if err := json.Unmarshal(jsonConfig, &config); err != nil {
-			t.Fatalf("We could not load the config ", err)
+	mc := NewMongoStoreClient(testingConfig)
+
+	/*
+	 * INIT THE TEST - we use a clean copy of the collection before we start
+	 */
+
+	//drop it like its hot
+	cpy := mc.session.Copy()
+	defer cpy.Close()
+
+	mgoConfirmationsCollection(cpy).DropCollection()
+
+	if err := mgoConfirmationsCollection(cpy).Create(&mgo.CollectionInfo{}); err != nil {
+		t.Fatalf("We couldn't created the users collection for these tests ", err)
+	}
+
+	//The basics
+	//+++++++++++++++++++++++++++
+	if err := mc.UpsertConfirmation(confirmation); err != nil {
+		t.Fatalf("we could not save the con %v", err)
+	}
+
+	if found, err := mc.FindConfirmation(confirmation); err == nil {
+		if found.Key == "" {
+			t.Fatalf("the confirmation string isn't included %v", found)
 		}
-
-		mc := NewMongoStoreClient(config.Mongo)
-
-		/*
-		 * INIT THE TEST - we use a clean copy of the collection before we start
-		 */
-
-		//drop it like its hot
-		cpy := mc.session.Copy()
-		defer cpy.Close()
-
-		mgoConfirmationsCollection(cpy).DropCollection()
-
-		if err := mgoConfirmationsCollection(cpy).Create(&mgo.CollectionInfo{}); err != nil {
-			t.Fatalf("We couldn't created the users collection for these tests ", err)
-		}
-
-		//The basics
-		//+++++++++++++++++++++++++++
-		if err := mc.UpsertConfirmation(confirmation); err != nil {
-			t.Fatalf("we could not save the con %v", err)
-		}
-
-		if found, err := mc.FindConfirmation(confirmation); err == nil {
-			if found.Key == "" {
-				t.Fatalf("the confirmation string isn't included %v", found)
-			}
-		} else {
-			t.Fatalf("no confirmation was returned when it should have been - err[%v]", err)
-		}
-
-		//when the conf doesn't exist
-		if found, err := mc.FindConfirmation(doesNotExist); err == nil && found != nil {
-			t.Fatalf("there should have been no confirmation found [%v]", found)
-		} else if err != nil {
-			t.Fatalf("and error was returned when it should not have been err[%v]", err)
-		}
-
-		if err := mc.RemoveConfirmation(confirmation); err != nil {
-			t.Fatalf("we could not remove the confirmation %v", err)
-		}
-
-		if confirmation, err := mc.FindConfirmation(confirmation); err == nil {
-			if confirmation != nil {
-				t.Fatalf("the confirmation has been removed so we shouldn't find it %v", confirmation)
-			}
-		}
-
-		//Find with other statuses
-		const fromUser, toUser, toEmail, toOtherEmail = "999.111", "312.123", "some@email.org", "some@other.org"
-		c1, _ := models.NewConfirmation(models.TypeCareteamInvite, fromUser)
-		c1.UserId = toUser
-		c1.Email = toEmail
-		c1.UpdateStatus(models.StatusDeclined)
-		mc.UpsertConfirmation(c1)
-
-		c2, _ := models.NewConfirmation(models.TypeCareteamInvite, fromUser)
-		c2.Email = toOtherEmail
-		c2.UpdateStatus(models.StatusCompleted)
-		mc.UpsertConfirmation(c2)
-
-		searchForm := &models.Confirmation{CreatorId: fromUser}
-
-		if confirmations, err := mc.FindConfirmations(searchForm, models.StatusDeclined, models.StatusCompleted); err == nil {
-			if len(confirmations) != 2 {
-				t.Fatalf("we should have found 2 confirmations %v", confirmations)
-			}
-
-			t1 := confirmations[0].Created
-			t2 := confirmations[1].Created
-
-			if t1.After(t2) {
-				t.Fatalf("the newest confirmtion should be first %v", confirmations)
-			}
-
-			if confirmations[0].Status != models.StatusCompleted && confirmations[0].Status != models.StatusDeclined {
-				t.Fatalf("status invalid: %s", confirmations[0].Status)
-			}
-			if confirmations[1].Status != models.StatusCompleted && confirmations[1].Status != models.StatusDeclined {
-				t.Fatalf("status invalid: %s", confirmations[1].Status)
-			}
-		}
-		searchToOtherEmail := &models.Confirmation{CreatorId: fromUser, Email: toOtherEmail}
-		//only email address
-		if confirmations, err := mc.FindConfirmations(searchToOtherEmail, models.StatusDeclined, models.StatusCompleted); err == nil {
-			if len(confirmations) != 1 {
-				t.Fatalf("we should have found 1 confirmations %v", confirmations)
-			}
-			if confirmations[0].Email != toOtherEmail {
-				t.Fatalf("should be for email: %s", toOtherEmail)
-			}
-			if confirmations[0].Status != models.StatusCompleted && confirmations[0].Status != models.StatusDeclined {
-				t.Fatalf("status invalid: %s", confirmations[0].Status)
-			}
-		}
-		searchToEmail := &models.Confirmation{CreatorId: fromUser, Email: toEmail}
-		//with both userid and email address
-		if confirmations, err := mc.FindConfirmations(searchToEmail, models.StatusDeclined, models.StatusCompleted); err == nil {
-			if len(confirmations) != 1 {
-				t.Fatalf("we should have found 1 confirmations %v", confirmations)
-			}
-			if confirmations[0].UserId != toUser {
-				t.Fatalf("should be for user: %s", toUser)
-			}
-			if confirmations[0].Email != toEmail {
-				t.Fatalf("should be for email: %s", toEmail)
-			}
-			if confirmations[0].Status != models.StatusCompleted && confirmations[0].Status != models.StatusDeclined {
-				t.Fatalf("status invalid: %s", confirmations[0].Status)
-			}
-		}
-
 	} else {
-		t.Fatalf("wtf - failed parsing the config %v", err)
+		t.Fatalf("no confirmation was returned when it should have been - err[%v]", err)
+	}
+
+	//when the conf doesn't exist
+	if found, err := mc.FindConfirmation(doesNotExist); err == nil && found != nil {
+		t.Fatalf("there should have been no confirmation found [%v]", found)
+	} else if err != nil {
+		t.Fatalf("and error was returned when it should not have been err[%v]", err)
+	}
+
+	if err := mc.RemoveConfirmation(confirmation); err != nil {
+		t.Fatalf("we could not remove the confirmation %v", err)
+	}
+
+	if confirmation, err := mc.FindConfirmation(confirmation); err == nil {
+		if confirmation != nil {
+			t.Fatalf("the confirmation has been removed so we shouldn't find it %v", confirmation)
+		}
+	}
+
+	//Find with other statuses
+	const fromUser, toUser, toEmail, toOtherEmail = "999.111", "312.123", "some@email.org", "some@other.org"
+	c1, _ := models.NewConfirmation(models.TypeCareteamInvite, fromUser)
+	c1.UserId = toUser
+	c1.Email = toEmail
+	c1.UpdateStatus(models.StatusDeclined)
+	mc.UpsertConfirmation(c1)
+
+	c2, _ := models.NewConfirmation(models.TypeCareteamInvite, fromUser)
+	c2.Email = toOtherEmail
+	c2.UpdateStatus(models.StatusCompleted)
+	mc.UpsertConfirmation(c2)
+
+	searchForm := &models.Confirmation{CreatorId: fromUser}
+
+	if confirmations, err := mc.FindConfirmations(searchForm, models.StatusDeclined, models.StatusCompleted); err == nil {
+		if len(confirmations) != 2 {
+			t.Fatalf("we should have found 2 confirmations %v", confirmations)
+		}
+
+		t1 := confirmations[0].Created
+		t2 := confirmations[1].Created
+
+		if t1.After(t2) {
+			t.Fatalf("the newest confirmtion should be first %v", confirmations)
+		}
+
+		if confirmations[0].Status != models.StatusCompleted && confirmations[0].Status != models.StatusDeclined {
+			t.Fatalf("status invalid: %s", confirmations[0].Status)
+		}
+		if confirmations[1].Status != models.StatusCompleted && confirmations[1].Status != models.StatusDeclined {
+			t.Fatalf("status invalid: %s", confirmations[1].Status)
+		}
+	}
+	searchToOtherEmail := &models.Confirmation{CreatorId: fromUser, Email: toOtherEmail}
+	//only email address
+	if confirmations, err := mc.FindConfirmations(searchToOtherEmail, models.StatusDeclined, models.StatusCompleted); err == nil {
+		if len(confirmations) != 1 {
+			t.Fatalf("we should have found 1 confirmations %v", confirmations)
+		}
+		if confirmations[0].Email != toOtherEmail {
+			t.Fatalf("should be for email: %s", toOtherEmail)
+		}
+		if confirmations[0].Status != models.StatusCompleted && confirmations[0].Status != models.StatusDeclined {
+			t.Fatalf("status invalid: %s", confirmations[0].Status)
+		}
+	}
+	searchToEmail := &models.Confirmation{CreatorId: fromUser, Email: toEmail}
+	//with both userid and email address
+	if confirmations, err := mc.FindConfirmations(searchToEmail, models.StatusDeclined, models.StatusCompleted); err == nil {
+		if len(confirmations) != 1 {
+			t.Fatalf("we should have found 1 confirmations %v", confirmations)
+		}
+		if confirmations[0].UserId != toUser {
+			t.Fatalf("should be for user: %s", toUser)
+		}
+		if confirmations[0].Email != toEmail {
+			t.Fatalf("should be for email: %s", toEmail)
+		}
+		if confirmations[0].Status != models.StatusCompleted && confirmations[0].Status != models.StatusDeclined {
+			t.Fatalf("status invalid: %s", confirmations[0].Status)
+		}
 	}
 }

--- a/config/server.json
+++ b/config/server.json
@@ -12,12 +12,12 @@
   "hydrophone" : {
     "serverSecret": "This needs to be the same secret everywhere. YaHut75NsK1f9UKUXuWqxNN0RUwHFBCy",
     "emailTemplates" : {
-      "passwordReset" : "{{define \"pwreset_test\"}} A test pw reset email  {{ .Email }} {{ .Key }} {{end}} {{template \"pwreset_test\" .}}",
+      "passwordReset" : "{{define \"password_reset\"}} A test pw reset email  {{ .Email }} {{ .Key }} {{end}} {{template \"password_reset\" .}}",
       "passwordResetSubject" : "Test password reset",
-      "careteamInvite" : "{{define \"invite\"}} <html> <head> <title>Please be part of my diabetes care team</title> <meta content=\"text/html; charset=UTF-8\" http-equiv=\"content-type\"> </head> <body> <p>Hey there!</p> <p>I’d like you to take a look at my diabetes data with me. When you confirm below, you’ll be able to see the data{{if .ViewOnlyPerms}} and comment on what you see{{else}}, comment on what you see, and upload my devices, too{{end}}.</p> <p><a href='http://tidepool.org'>Tidepool</a> is a secure data hosting platform that supports apps made for people with diabetes.</p></body> </html> {{end}} {{template \"invite\" .}}",
+      "careteamInvite" : "{{define \"careteam_invitation\"}}  {{if .ViewOnlyPerms}} only can view {{else}}, comment and upload, too{{end}} {{end}} {{template \"careteam_invitation\" .}}",
       "careteamInviteSubject" : "Careteam invite",
-      "confirmation" : "{{define \"confirm_test\"}} A test confirmation email  {{ .Email }} {{ .Key }} {{end}} {{template \"confirm_test\" .}}",
-      "confirmationSubject" :"Confirmation"
+      "signUp" : "{{define \"email_confirmation\"}} A test confirmation email  {{ .Email }} {{ .Key }} {{end}} {{template \"email_confirmation\" .}}",
+      "signUpSubject" :"Signup Confirmation"
     },
     "inviteTimeoutDays": 7,
     "resetTimeoutDays": 7,

--- a/config/server.json
+++ b/config/server.json
@@ -12,11 +12,11 @@
   "hydrophone" : {
     "serverSecret": "This needs to be the same secret everywhere. YaHut75NsK1f9UKUXuWqxNN0RUwHFBCy",
     "emailTemplates" : {
-      "passwordReset" : "{{define \"password_reset\"}} A test pw reset email  {{ .Email }} {{ .Key }} {{end}} {{template \"password_reset\" .}}",
+      "passwordReset" : "{{define \"tst_reset\"}} A test pw reset email  {{ .Email }} {{ .Key }} {{end}} {{template \"tst_reset\" .}}",
       "passwordResetSubject" : "Test password reset",
-      "careteamInvite" : "{{define \"careteam_invitation\"}}  {{if .ViewOnlyPerms}} only can view {{else}}, comment and upload, too{{end}} {{end}} {{template \"careteam_invitation\" .}}",
+      "careteamInvite" : "{{define \"tst_invitation\"}}  {{if .ViewOnlyPerms}} only can view {{else}}, comment and upload, too{{end}} {{end}} {{template \"tst_invitation\" .}}",
       "careteamInviteSubject" : "Careteam invite",
-      "signUp" : "{{define \"email_confirmation\"}} A test confirmation email  {{ .Email }} {{ .Key }} {{end}} {{template \"email_confirmation\" .}}",
+      "signUp" : "{{define \"tst_signup\"}} A test confirmation email  {{ .Email }} {{ .Key }} {{end}} {{template \"tst_signup\" .}}",
       "signUpSubject" :"Signup Confirmation"
     },
     "inviteTimeoutDays": 7,

--- a/gotest
+++ b/gotest
@@ -1,0 +1,13 @@
+#! /bin/bash -eu
+# assumes that the build has been done at least once
+
+export GOPATH=`pwd`
+
+TESTDIRS=$(find . -name "*_test.go" -and ! -path "./src/*" |sed s@/[^/]*go@@ |sed s@./@@ |uniq)
+
+for i in $TESTDIRS; do
+    echo Testing in $i:
+    cd $i
+    go test -v
+    cd ..
+done

--- a/models/confirmation.go
+++ b/models/confirmation.go
@@ -36,7 +36,7 @@ const (
 	//Available Type's
 	TypePasswordReset  Type = "password_reset"
 	TypeCareteamInvite Type = "careteam_invitation"
-	TypeConfirmation   Type = "email_confirmation"
+	TypeSignUp         Type = "signup_confirmation"
 )
 
 //New confirmation with just the basics

--- a/models/template.go
+++ b/models/template.go
@@ -12,8 +12,8 @@ type (
 		PasswordResetSubject  string `json:"passwordResetSubject"`
 		CareteamInvite        string `json:"careteamInvite"`
 		CareteamInviteSubject string `json:"careteamInviteSubject"`
-		Confirmation          string `json:"confirmation"`
-		ConfirmationSubject   string `json:"confirmationSubject"`
+		Signup                string `json:"signUp"`
+		SignupSubject         string `json:"signUpSubject"`
 	}
 
 	Template struct {
@@ -40,9 +40,9 @@ func (t *Template) Load(templateType Type, cfg *TemplateConfig) {
 		compiled = template.Must(template.New(string(TypeCareteamInvite)).Parse(cfg.CareteamInvite))
 		subject = cfg.CareteamInviteSubject
 		break
-	case templateType == TypeConfirmation:
-		compiled = template.Must(template.New(string(TypeConfirmation)).Parse(cfg.Confirmation))
-		subject = cfg.ConfirmationSubject
+	case templateType == TypeSignUp:
+		compiled = template.Must(template.New(string(TypeSignUp)).Parse(cfg.Signup))
+		subject = cfg.SignupSubject
 		break
 	case templateType == TypePasswordReset:
 		compiled = template.Must(template.New(string(TypePasswordReset)).Parse(cfg.PasswordReset))

--- a/models/template_test.go
+++ b/models/template_test.go
@@ -34,7 +34,7 @@ Hi {{ .UserName }}
 {{template "invite_test" .}}
 `,
 		CareteamInviteSubject: "A Careteam Invite",
-		Confirmation: `
+		Signup: `
 {{define "confirm_test"}}
 ## Test Template
 {{ .UserName }}
@@ -42,7 +42,7 @@ Hi {{ .UserName }}
 {{end}}
 {{template "confirm_test" .}}
 `,
-		ConfirmationSubject: "A Confirmation",
+		SignupSubject: "A Confirmation",
 	}
 )
 
@@ -84,7 +84,7 @@ func TestParse(t *testing.T) {
 
 	tmpl := NewTemplate()
 
-	tmpl.Load(TypeConfirmation, cfg)
+	tmpl.Load(TypeSignUp, cfg)
 
 	tmpl.Parse(content)
 


### PR DESCRIPTION
* Rename to signup for consistency of confirmation naming
* use the mgo session copy pattern for mongo client
* update mongo tests to use specific test collection so we don't over-right any local env information 