### PR TITLE
if there is no account for pwrest send relevant email

### DIFF
--- a/api/forgot.go
+++ b/api/forgot.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	STATUS_RESET_NOT_FOUND = "No matching reset confirmation was found"
-	STATUS_RESET_ACCEPTED  = "Password has been reset"
-	STATUS_RESET_EXPIRED   = "Password reset confirmation has expired"
-	STATUS_RESET_ERROR     = "Error while reseting password, reset confirmation remains active until it expires"
+	STATUS_RESET_NOT_FOUND  = "No matching reset confirmation was found"
+	STATUS_RESET_ACCEPTED   = "Password has been reset"
+	STATUS_RESET_EXPIRED    = "Password reset confirmation has expired"
+	STATUS_RESET_ERROR      = "Error while reseting password, reset confirmation remains active until it expires"
+	STATUS_RESET_NO_ACCOUNT = "No matching account for the email was found"
 )
 
 type (
@@ -58,6 +59,13 @@ func (a *Api) passwordReset(res http.ResponseWriter, req *http.Request, vars map
 
 	if resetUsr := a.findExistingUser(resetCnf.Email, a.sl.TokenProvide()); resetUsr != nil {
 		resetCnf.UserId = resetUsr.UserID
+	} else {
+		log.Print(STATUS_RESET_NO_ACCOUNT)
+		log.Printf("email used [%s]", email)
+		resetCnf, _ = models.NewConfirmation(models.TypeNoAccount, "")
+		resetCnf.Email = email
+		//there is nothing more to do other than notify the user
+		resetCnf.UpdateStatus(models.StatusCompleted)
 	}
 
 	if a.addOrUpdateConfirmation(resetCnf, res) {

--- a/api/forgot.go
+++ b/api/forgot.go
@@ -12,11 +12,11 @@ import (
 )
 
 const (
-	STATUS_RESET_NOT_FOUND  = "No matching reset confirmation was found"
-	STATUS_RESET_ACCEPTED   = "Password has been reset"
-	STATUS_RESET_EXPIRED    = "Password reset confirmation has expired"
-	STATUS_RESET_ERROR      = "Error while reseting password, reset confirmation remains active until it expires"
-	STATUS_RESET_NO_ACCOUNT = "No matching account for the email was found"
+	STATUS_RESET_NOT_FOUND  = "No matching reset confirmation was found."
+	STATUS_RESET_ACCEPTED   = "Password has been reset."
+	STATUS_RESET_EXPIRED    = "Password reset confirmation has expired."
+	STATUS_RESET_ERROR      = "Error while resetting password; reset confirmation remains active until it expires."
+	STATUS_RESET_NO_ACCOUNT = "No matching account for the email was found."
 )
 
 type (

--- a/api/forgot_test.go
+++ b/api/forgot_test.go
@@ -20,6 +20,13 @@ func TestForgotResponds(t *testing.T) {
 			respCode: 200,
 		},
 		{
+			// always returns a 200 if properly formed
+			returnNone: true,
+			method:     "POST",
+			url:        "/send/forgot/me@myemail.com",
+			respCode:   200,
+		},
+		{
 			method:   "PUT",
 			url:      "/accept/forgot",
 			respCode: 200,

--- a/models/confirmation.go
+++ b/models/confirmation.go
@@ -37,6 +37,7 @@ const (
 	TypePasswordReset  Type = "password_reset"
 	TypeCareteamInvite Type = "careteam_invitation"
 	TypeSignUp         Type = "signup_confirmation"
+	TypeNoAccount      Type = "no_account"
 )
 
 //New confirmation with just the basics

--- a/models/template.go
+++ b/models/template.go
@@ -14,6 +14,8 @@ type (
 		CareteamInviteSubject string `json:"careteamInviteSubject"`
 		Signup                string `json:"signUp"`
 		SignupSubject         string `json:"signUpSubject"`
+		NoAccount             string `json:"noAccount"`
+		NoAccountSubject      string `json:"noAccountSubject"`
 	}
 
 	Template struct {
@@ -47,6 +49,10 @@ func (t *Template) Load(templateType Type, cfg *TemplateConfig) {
 	case templateType == TypePasswordReset:
 		compiled = template.Must(template.New(string(TypePasswordReset)).Parse(cfg.PasswordReset))
 		subject = cfg.PasswordResetSubject
+		break
+	case templateType == TypeNoAccount:
+		compiled = template.Must(template.New(string(TypeNoAccount)).Parse(cfg.NoAccount))
+		subject = cfg.NoAccountSubject
 		break
 	default:
 		log.Println("Unknown type ", templateType)


### PR DESCRIPTION
we still leak no details from service but can now send user email say
‘hey it looks like your trying to reset a pw for an account that
doesn’t exist, do you want to create one?’….

see https://trello.com/c/FE5fQQPV for details

@kentquirk