### PR TITLE
Allow sending signup confirmation again if email has changed; update tests

### DIFF
--- a/clients/mockStoreClient.go
+++ b/clients/mockStoreClient.go
@@ -44,6 +44,9 @@ func (d *MockStoreClient) FindConfirmation(notification *models.Confirmation) (r
 	if notification.UserId == "" {
 		notification.UserId = notification.Key
 	}
+	if notification.Email == "" {
+		notification.Email = notification.UserId
+	}
 
 	notification.Created = time.Now().AddDate(0, 0, -3) // created three days ago
 	return notification, nil


### PR DESCRIPTION
@jh-bate This allows custodians (i.e. a clinic) to update the email of a patient account (not yet verified) and send a new signup verification email to the updated email address. It updates the /confirm/send/signup/{userid} endpoint to check if a confirmation already exists for the user id *with a confirmation email address that differs from the user email address* and then updates the confirmation email to match the user and sends the verification email to the new email address.

I couldn't figure out how to shoe-horn a test into the test structure for this project without significant effort. I tested manually and it works as designed.