### PR TITLE
careteam name should be set to the fullName ...

### DIFF
--- a/api/invite.go
+++ b/api/invite.go
@@ -381,9 +381,14 @@ func (a *Api) SendInvite(res http.ResponseWriter, req *http.Request, vars map[st
 				} else {
 
 					canUpload := ib.Permissions["upload"]
+					fullName := invite.Creator.Profile.FullName
+
+					if invite.Creator.Profile.Patient.IsOtherPerson {
+						fullName = invite.Creator.Profile.Patient.FullName
+					}
 
 					emailContent := map[string]interface{}{
-						"CareteamName":   invite.Creator.Profile.FullName,
+						"CareteamName":   fullName,
 						"Key":            invite.Key,
 						"Email":          invite.Email,
 						"IsExistingUser": invite.UserId != "",

--- a/models/confirmation.go
+++ b/models/confirmation.go
@@ -29,10 +29,11 @@ type (
 		*Profile `json:"profile" bson:"-"`
 		UserId   string `json:"userid" bson:"-"` //for compatability with blip
 	}
-
-	//cutdown verson of a profile used for confirmations
 	Patient struct {
-		Birthday string `json:"birthday"`
+		Birthday      string `json:"birthday"`
+		DiagnosisDate string `json:"diagnosisDate"`
+		IsOtherPerson bool   `json:"isOtherPerson"`
+		FullName      string `json:"fullName"`
 	}
 	Profile struct {
 		FullName string  `json:"fullName"`
@@ -95,7 +96,6 @@ func NewConfirmation(theType Type, templateName TemplateName, creatorId string) 
 
 //New confirmation that includes context data
 func NewConfirmationWithContext(theType Type, templateName TemplateName, creatorId string, data interface{}) (*Confirmation, error) {
-
 	if conf, err := NewConfirmation(theType, templateName, creatorId); err != nil {
 		return nil, err
 	} else {


### PR DESCRIPTION
> As a clinician, when I'm invited to join a careteam, I want to see the name of the person whose care team it is, not the name of a parent or guadian, so I know I'm accepting the invitation for the correct person.

See card https://trello.com/c/NMr0pTEF 