### PR TITLE
Remove legacy url fragment from Blip URLs in email templates

### DIFF
--- a/templates/careteam_invite.go
+++ b/templates/careteam_invite.go
@@ -28,11 +28,11 @@ const _CareteamInviteBodyTemplate string = `
 
       {{if .IsExistingUser}}
       <div align='center' style='padding:0;'>
-        <a style='background-color:#627CFB; font-family: Nunito, sans-serif, Helvetica Neue, Helvetica; font-weight:400; font-size: 14px; color:#FFFFFF; padding:10px 20px; margin:0; border-radius:20px; text-decoration: none;' href='{{ .BlipURL }}/#/login?inviteEmail={{ .Email }}&inviteKey={{ .Key }}'>Join {{ .CareteamName }}'s Care Team</a>
+        <a style='background-color:#627CFB; font-family: Nunito, sans-serif, Helvetica Neue, Helvetica; font-weight:400; font-size: 14px; color:#FFFFFF; padding:10px 20px; margin:0; border-radius:20px; text-decoration: none;' href='{{ .BlipURL }}/login?inviteEmail={{ .Email }}&inviteKey={{ .Key }}'>Join {{ .CareteamName }}'s Care Team</a>
       </div>
       {{else}}
       <div align='center' style='padding:0;'>
-        <a style='background-color:#627CFB; font-family: Nunito, sans-serif, Helvetica Neue, Helvetica; font-weight:400; font-size: 14px; color:#FFFFFF; padding:10px 20px; margin:0; border-radius:20px; text-decoration: none;' href='{{ .BlipURL }}/#/signup?inviteEmail={{ .Email }}&inviteKey={{ .Key }}'>Join {{ .CareteamName }}'s Care Team</a>
+        <a style='background-color:#627CFB; font-family: Nunito, sans-serif, Helvetica Neue, Helvetica; font-weight:400; font-size: 14px; color:#FFFFFF; padding:10px 20px; margin:0; border-radius:20px; text-decoration: none;' href='{{ .BlipURL }}/signup?inviteEmail={{ .Email }}&inviteKey={{ .Key }}'>Join {{ .CareteamName }}'s Care Team</a>
       </div>
       {{end}}
 

--- a/templates/no_account.go
+++ b/templates/no_account.go
@@ -27,7 +27,7 @@ const _NoAccountBodyTemplate string = `
       <br>
 
       <div align='center' style='padding:0;'>
-        <a style='background-color:#627CFB; font-family: Nunito, sans-serif, Helvetica Neue, Helvetica; font-weight:400; font-size: 14px; color:#FFFFFF; padding:10px 20px; margin:0; border-radius:20px; text-decoration: none;' href='{{ .BlipURL }}/#/signup'>Sign Up</a>
+        <a style='background-color:#627CFB; font-family: Nunito, sans-serif, Helvetica Neue, Helvetica; font-weight:400; font-size: 14px; color:#FFFFFF; padding:10px 20px; margin:0; border-radius:20px; text-decoration: none;' href='{{ .BlipURL }}/signup'>Sign Up</a>
       </div>
 
       <br>

--- a/templates/password_reset.go
+++ b/templates/password_reset.go
@@ -27,7 +27,7 @@ const _PasswordResetBodyTemplate string = `
       <br>
 
       <div align='center' style='padding:0;'>
-        <a style='background-color:#627CFB; font-family: Nunito, sans-serif, Helvetica Neue, Helvetica; font-weight:400; font-size: 14px; color:#FFFFFF; padding:10px 20px; margin:0; border-radius:20px; text-decoration: none;' href='{{ .BlipURL }}/#/confirm-password-reset?resetKey={{ .Key }}'>Reset Password</a>
+        <a style='background-color:#627CFB; font-family: Nunito, sans-serif, Helvetica Neue, Helvetica; font-weight:400; font-size: 14px; color:#FFFFFF; padding:10px 20px; margin:0; border-radius:20px; text-decoration: none;' href='{{ .BlipURL }}/confirm-password-reset?resetKey={{ .Key }}'>Reset Password</a>
       </div>
 
       <br>

--- a/templates/signup.go
+++ b/templates/signup.go
@@ -27,7 +27,7 @@ const _SignupBodyTemplate string = `
       <br>
 
       <div align='center' style='padding:0;'>
-        <a style='background-color:#627CFB; font-family: Nunito, sans-serif, Helvetica Neue, Helvetica; font-weight:400; font-size: 14px; color:#FFFFFF; padding:10px 20px; margin:0; border-radius:20px; text-decoration: none;' href='{{ .BlipURL }}/#/login?signupEmail={{ .Email }}&signupKey={{ .Key }}'>Verify Your Account</a>
+        <a style='background-color:#627CFB; font-family: Nunito, sans-serif, Helvetica Neue, Helvetica; font-weight:400; font-size: 14px; color:#FFFFFF; padding:10px 20px; margin:0; border-radius:20px; text-decoration: none;' href='{{ .BlipURL }}/login?signupEmail={{ .Email }}&signupKey={{ .Key }}'>Verify Your Account</a>
       </div>
 
       <br>

--- a/templates/signup_custodial_clinic.go
+++ b/templates/signup_custodial_clinic.go
@@ -29,7 +29,7 @@ const _SignupCustodialClinicBodyTemplate string = `
       <br>
 
       <div align='center' style='padding:0;'>
-        <a style='background-color:#627CFB; font-family: Nunito, sans-serif, Helvetica Neue, Helvetica; font-weight:400; font-size: 14px; color:#FFFFFF; padding:10px 20px; margin:0; border-radius:20px; text-decoration: none;' href='{{ .BlipURL }}/#/login?signupEmail={{ .Email }}&signupKey={{ .Key }}'>Claim Your Account</a>
+        <a style='background-color:#627CFB; font-family: Nunito, sans-serif, Helvetica Neue, Helvetica; font-weight:400; font-size: 14px; color:#FFFFFF; padding:10px 20px; margin:0; border-radius:20px; text-decoration: none;' href='{{ .BlipURL }}/login?signupEmail={{ .Email }}&signupKey={{ .Key }}'>Claim Your Account</a>
       </div>
 
       <br>


### PR DESCRIPTION
What is says on the tin. Should fix bug in Gmail on Safari not using full URL (https://trello.com/c/Gu7HHAz6).