### PR TITLE
Review Travis build for forked repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: go
 go:
   - 1.9.2
 
+go_import_path: github.com/tidepool-org/hydrophone
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
The default Travis build is problematic for forked repositories because of the way Go imports the packages and dependencies for the build (see http://www.ruflin.com/2015/08/13/fix-for-travis-ci-failure-in-forked-golang-repositories/).

This PR is a proposal for adding "go_import_path" instruction to fix this problem with forked repositories (https://docs.travis-ci.com/user/languages/go/#go-import-path). This is done the same in some other modules such as "platform".