### PR TITLE
Mods for Kubernetes

### DIFF
--- a/hydrophone.go
+++ b/hydrophone.go
@@ -39,6 +39,17 @@ func main() {
 		log.Panic("Problem loading config ", err)
 	}
 
+	// ses secrets may be passed via a separate env variable to accomodate easy secrets injection via Kubernetes
+	accessSecret, found := os.LookupEnv("SES_ACCESS_KEY")
+	if found {
+		config.Mail.AccessKey = accessSecret
+	}
+
+	secretKey, found := os.LookupEnv("SES_SECRET_KEY")
+	if found {
+		config.Mail.SecretKey = secretKey
+	}
+
 	// server secret may be passed via a separate env variable to accomodate easy secrets injection via Kubernetes
 	serverSecret, found := os.LookupEnv("SERVER_SECRET")
 	if found {

--- a/vendor/github.com/tidepool-org/go-common/clients/hakken/hakken.go
+++ b/vendor/github.com/tidepool-org/go-common/clients/hakken/hakken.go
@@ -22,6 +22,7 @@ type HakkenClientConfig struct {
 	HeartbeatInterval jepson.Duration `json:"heartbeatInterval"` // Time elapsed between heartbeats and watch polls
 	PollInterval      jepson.Duration `json:"pollInterval"`      // Time elapsed between coordinator gossip polls
 	ResyncInterval    jepson.Duration `json:"resyncInterval"`    // Time elapsed between checks for new coordinators at Host
+	SkipHakken        bool            `json:"skipHakken"`        // True is Hakken service is not used
 }
 
 type HakkenClientBuilder struct {


### PR DESCRIPTION
The first mod is to ignore hakken.
The second is to use top level env variables instead of nested ones WHEN they are provided.