### PR TITLE
Guard use of SNYK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ services:
 script:
   - ./build.sh
   - ./test.sh
-  - 'if [ -n $SNYK_TOKEN ]; then snyk test --dev --org=tidepool; fi'
-  - 'if [ -n $SNYK_TOKEN ]; then snyk monitor --org=tidepool; fi'
+  - 'if [[ -n $SNYK_TOKEN ]]; then snyk test --dev --org=tidepool; fi'
+  - 'if [[ -n $SNYK_TOKEN ]]; then snyk monitor --org=tidepool; fi'
   - ./artifact.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ services:
 script:
   - ./build.sh
   - ./test.sh
-  - snyk test --dev --org=tidepool
-  - snyk monitor --org=tidepool
+  - 'if [ -n $SNYK_TOKEN ]; then snyk test --dev --org=tidepool; fi'
+  - 'if [ -n $SNYK_TOKEN ]; then snyk monitor --org=tidepool; fi'
   - ./artifact.sh


### PR DESCRIPTION
Snyk should not be used when the auth token is not available.