### PR TITLE
[BACK-1193] Fix incorrect scope of resend signup confirmation query

### DIFF
--- a/api/signup.go
+++ b/api/signup.go
@@ -233,7 +233,7 @@ func (a *Api) sendSignUp(res http.ResponseWriter, req *http.Request, vars map[st
 func (a *Api) resendSignUp(res http.ResponseWriter, req *http.Request, vars map[string]string) {
 	email := vars["useremail"]
 
-	toFind := &models.Confirmation{Email: email, Status: models.StatusPending}
+	toFind := &models.Confirmation{Email: email, Status: models.StatusPending, Type: models.TypeSignUp}
 
 	if found := a.findSignUp(toFind, res); found != nil {
 		if err := a.Store.RemoveConfirmation(found); err != nil {


### PR DESCRIPTION
If a user signed up and requested a password reset email before verifying their account, a subsequent account confirmation request would result in a password reset email. This was caused by an incorrect mongo query.