### PR TITLE
[WEB-1159] Allow resending a careteam invitation by providing existing 'key' in request body

### DIFF
--- a/api/invite.go
+++ b/api/invite.go
@@ -398,7 +398,7 @@ func (a *Api) SendInvite(res http.ResponseWriter, req *http.Request, vars map[st
 			log.Printf("SendInvite: invited [%s] user already has or had an invite", ib.Email)
 			return
 		} else {
-			// No pending invide exists, or we're intentionally resending so lets prepare the invite
+			// No pending invite exists, or we're intentionally resending so lets prepare the invite
 			invite, _ := models.NewConfirmationWithContext(models.TypeCareteamInvite, models.TemplateNameCareteamInvite, invitorID, ib.Permissions)
 
 			invite.Email = ib.Email

--- a/api/invite_test.go
+++ b/api/invite_test.go
@@ -156,6 +156,21 @@ func TestInviteResponds(t *testing.T) {
 			},
 		},
 		{
+			desc:     "can have a duplicate invite if key is provided",
+			method:   http.MethodPost,
+			url:      fmt.Sprintf("/send/invite/%s", testing_uid2),
+			token:    testing_token_uid1,
+			respCode: http.StatusOK,
+			body: testJSONObject{
+				"key":   "abc123",
+				"email": testing_uid2 + "@email.org",
+				"permissions": testJSONObject{
+					"view": testJSONObject{},
+					"note": testJSONObject{},
+				},
+			},
+		},
+		{
 			desc:       "invite valid if email, permissons and not a duplicate",
 			returnNone: true,
 			method:     http.MethodPost,

--- a/models/confirmation.go
+++ b/models/confirmation.go
@@ -18,10 +18,10 @@ type (
 		Creator   Creator         `json:"creator" bson:"creator"`
 		Context   json.RawMessage `json:"context" bson:"context,omitempty"`
 		Created   time.Time       `json:"created" bson:"created"`
+		Status    Status          `json:"status" bson:"status"`
 
 		TemplateName TemplateName `json:"-" bson:"templateName"`
 		UserId       string       `json:"-" bson:"userId"`
-		Status       Status       `json:"-" bson:"status"`
 		Modified     time.Time    `json:"-" bson:"modified"`
 	}
 


### PR DESCRIPTION
Hi Todd.  I just wanted to get your eyes on this to see if you think it's a reasonable solution for adding the ability to resend an invite to a patients care team (see [WEB-1159] for details)

While working on the frontend ticket, I realized that we don't have the ability to do this currently, so these changes were made locally, kind of just as a way of looking into the feasibility of doing it with our current invite sending structure, and giving me a quick way of building our the frontend UI.

It's a pretty simple approach.  I thought about adding a new API endpoint for this, and deleting the current invitation prior to issuing a new one (which is what we do in `resendSignUp`) , but since this required only minor changes to the current `SendInvite` API handler to support resends, I thought it was worth getting your eyes on it so you can decide if you'd like to move forward with this approach or have me create a new backend Jira ticket to support this requirement.

Only other change is returning the status of the invitation in the JSON, again, to meet a UI requirement (showing `declined` vs `pending` status on Tidepool Web).

[WEB-1159]: https://tidepool.atlassian.net/browse/WEB-1159