### PR TITLE
[BACK-2239] Use mock email notifier via environment variable 

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,37 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main hydrophone.go"
+  delay = 2000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = ["Dockerfile"]
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html", "test"]
+  kill_delay = "0s"
+  log = "build-errors.log"
+  send_interrupt = false
+  stop_on_error = true
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 # Development
-FROM golang:1.15.2-alpine AS development
+FROM golang:1.17-alpine AS development
 WORKDIR /go/src/github.com/tidepool-org/hydrophone
 RUN adduser -D tidepool && \
     chown -R tidepool /go/src/github.com/tidepool-org/hydrophone
 USER tidepool
+RUN go install github.com/cosmtrek/air@latest
 COPY --chown=tidepool . .
 RUN ./build.sh
-CMD ["./dist/hydrophone"]
+CMD ["air"]
 
 # Production
 FROM alpine:latest AS production


### PR DESCRIPTION
[BACK-2239] 

Allows using the existing test mock notifier rather than SES via an environment variable for local Tilt stack operation.
Also updates `development` docker build target to use `air` for live updates.

[Related development PR for adding the env var](https://github.com/tidepool-org/development/pull/207)

[BACK-2239]: https://tidepool.atlassian.net/browse/BACK-2239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ