### PR TITLE
[BACK-2238,BACK-2239] Fix clinician invite dismissal error

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,37 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main hydrophone.go"
+  delay = 2000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = ["Dockerfile"]
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html", "test"]
+  kill_delay = "0s"
+  log = "build-errors.log"
+  send_interrupt = false
+  stop_on_error = true
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Development
-FROM golang:1.17-alpine AS development
+FROM golang:1.19-alpine AS development
 WORKDIR /go/src/github.com/tidepool-org/hydrophone
 RUN adduser -D tidepool && \
     chown -R tidepool /go/src/github.com/tidepool-org/hydrophone

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 # Development
-FROM golang:1.15.2-alpine AS development
+FROM golang:1.17-alpine AS development
 WORKDIR /go/src/github.com/tidepool-org/hydrophone
 RUN adduser -D tidepool && \
     chown -R tidepool /go/src/github.com/tidepool-org/hydrophone
 USER tidepool
+RUN go install github.com/cosmtrek/air@latest
 COPY --chown=tidepool . .
 RUN ./build.sh
-CMD ["./dist/hydrophone"]
+CMD ["air"]
 
 # Production
 FROM alpine:latest AS production


### PR DESCRIPTION
[BACK-2238] [BACK-2239]
Basically, `cancelClinicianInviteWithStatus` is being called for both deleting a clinician invitation to a clinic, as well as dismissing the invitation (as the clinician user)

In the latter case, we didn't have the `ClinicId` supplied in the `filter` arg, and so the call to delete the clinician invite was failing due to the `ClinicID` being missing as a route parameter in the API call sent.

Note: this PR also includes the changes approved in the [local mock email notifier PR](https://github.com/tidepool-org/hydrophone/pull/109)

[BACK-2238]: https://tidepool.atlassian.net/browse/BACK-2238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BACK-2239]: https://tidepool.atlassian.net/browse/BACK-2239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ