### PR TITLE
[BACK-2290] Tweaks for signup confirmation upsert user not found error

### DIFF
--- a/api/signup.go
+++ b/api/signup.go
@@ -415,7 +415,7 @@ func (a *Api) upsertSignUp(res http.ResponseWriter, req *http.Request, vars map[
 
 		if usrDetails, err := a.sl.GetUser(userId, a.sl.TokenProvide()); err != nil {
 			log.Printf("upsertSignUp %s err[%s]", STATUS_ERR_FINDING_USER, err.Error())
-			a.sendModelAsResWithStatus(res, status.StatusError{Status: status.NewStatus(http.StatusInternalServerError, STATUS_ERR_FINDING_USER)}, http.StatusNotFound)
+			a.sendModelAsResWithStatus(res, status.StatusError{Status: status.NewStatus(http.StatusNotFound, STATUS_ERR_FINDING_USER)}, http.StatusNotFound)
 			return nil
 		} else if len(usrDetails.Emails) == 0 {
 			// Delete existing any existing invites if the email address is empty

--- a/api/signup.go
+++ b/api/signup.go
@@ -415,7 +415,7 @@ func (a *Api) upsertSignUp(res http.ResponseWriter, req *http.Request, vars map[
 
 		if usrDetails, err := a.sl.GetUser(userId, a.sl.TokenProvide()); err != nil {
 			log.Printf("upsertSignUp %s err[%s]", STATUS_ERR_FINDING_USER, err.Error())
-			a.sendModelAsResWithStatus(res, status.StatusError{Status: status.NewStatus(http.StatusInternalServerError, STATUS_ERR_FINDING_USER)}, http.StatusInternalServerError)
+			a.sendModelAsResWithStatus(res, status.StatusError{Status: status.NewStatus(http.StatusInternalServerError, STATUS_ERR_FINDING_USER)}, http.StatusNotFound)
 			return nil
 		} else if len(usrDetails.Emails) == 0 {
 			// Delete existing any existing invites if the email address is empty


### PR DESCRIPTION
Addresses an issue I had locally with [BACK-2290]
If a user was not found (such as if they'd been deleted) the signup confirmation upsert would throw a 500 error that would cause clinic-worker to hang until the kafka message queue was cleared.

It seemed to me that it should be fine to return a 404 in this case, and not error within clinic-worker in this scenario.  There were already other places within clinic worker ([PR](https://github.com/tidepool-org/clinic-worker/pull/31)) where we handle 404's on users without throwing, so I thought this made sense to change.  Let me know if you'd prefer to not.

[BACK-2290]: https://tidepool.atlassian.net/browse/BACK-2290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ