### PR TITLE
re-organize tool installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 hydrophone
 artifact_go.sh
 .DS_Store
+/node_modules/
+/tools/

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,48 @@
-# Clinic Makefile
+SHELL = /bin/sh
 
+TOOLS_BIN = tools/bin
+NPM_BIN = node_modules/.bin
+
+OAPI_CODEGEN = $(TOOLS_BIN)/oapi-codegen
+SWAGGER_CLI = $(NPM_BIN)/swagger-cli
+
+NPM_PKG_SPECS = \
+	@apidevtools/swagger-cli@^4.0.4
+
+
+.PHONY: all
+all: dist/hydrophone
+
+GENERATED_SRCS = client/types.go client/client.go spec/confirm.v1.yaml
+
+dist/hydrophone: $(GENERATED_SRCS)
+	GOWORK=off ./build.sh
+
+.PHONY: build
+build:
+	$(MAKE) dist/hydrophone
+
+.PHONY: generate
 # Generates client api
-generate:
-	swagger-cli bundle ../TidepoolApi/reference/confirm.v1.yaml -o ./spec/confirm.v1.yaml -t yaml
-	oapi-codegen -package=api -generate=types spec/confirm.v1.yaml > client/types.go
-	oapi-codegen -package=api -generate=client spec/confirm.v1.yaml > client/client.go
+generate: $(SWAGGER_CLI) $(OAPI_CODEGEN)
+	$(SWAGGER_CLI) bundle ../TidepoolApi/reference/confirm.v1.yaml -o ./spec/confirm.v1.yaml -t yaml
+	$(OAPI_CODEGEN) -package=api -generate=types spec/confirm.v1.yaml > client/types.go
+	$(OAPI_CODEGEN) -package=api -generate=client spec/confirm.v1.yaml > client/client.go
 	cd client && go generate ./...
 
+.PHONY: test
 test:
 	GOWORK=off ./test.sh
+
+$(OAPI_CODEGEN):
+	GOBIN=$(shell pwd)/$(TOOLS_BIN) go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.13.4
+
+$(SWAGGER_CLI):
+	npm-tools
+
+.PHONY: npm-tools
+npm-tools:
+# When using --no-save, any dependencies not included will be deleted, so one
+# has to install all the packages all at the same time. But it saves us from
+# having to muck with packages.json.
+	npm i --no-save --local $(NPM_PKG_SPECS)

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,3 @@
 #!/bin/sh -eu
 
-rm -rf dist
-mkdir dist
 go build -o dist/hydrophone hydrophone.go


### PR DESCRIPTION
Before this change, tools were installed on the user's system, outside of the project directory, some into `npm --global prefix`, others in `GOPATH`. This can be annoying, as it can overwrite existing tools, or different projects with requirements on different versions of tools can conflict.

The tools have been re-organized, so that they're all installed by the Makefile, and placed within the project directory. Specifically, go binaries are in tools/bin, and node scripts are in node_modules/.bin. The scripts have been edited to modify their paths to prefer the use of these project-specified tools, so that conflicts with other user-installed tools should be prevented.

I also spent a little time doing some shell script cleanup, little things like quoting arguments, checking for required arguments and the like.

Oh, and I versioned the go tools that were being installed. No one likes having those @latest surprises on a production deployment!