### PR TITLE
adds AlertsConfig data types for care team alerting

### DIFF
--- a/models/confirmation.go
+++ b/models/confirmation.go
@@ -252,23 +252,52 @@ func generateKey() (string, error) {
 // AlertsConfig is included with a care team invitation to configure initial
 // alerts for the invitation's recipient.
 type AlertsConfig struct {
-	UrgentLow       AlertConfig `json:"urgentLow"`
-	Low             AlertConfig `json:"low"`
-	High            AlertConfig `json:"high"`
-	NotLooping      AlertConfig `json:"notLooping"`
-	NoCommunication AlertConfig `json:"noCommunication"`
+	UrgentLow       AlertConfigWithThreshold `json:"urgentLow"`
+	Low             AlertConfigDeluxe        `json:"low"`
+	High            AlertConfigDeluxe        `json:"high"`
+	NotLooping      AlertConfigWithDelay     `json:"notLooping"`
+	NoCommunication AlertConfigWithDelay     `json:"noCommunication"`
 }
 
-// AlertConfig describes the specifics of a desired alert.
-type AlertConfig struct {
+// AlertConfigBase describes the minimum specifics of a desired alert.
+type AlertConfigBase struct {
 	// Enabled controls whether notifications should be sent for this alert.
 	Enabled bool
-	// Threshold is measured in mg/dL.
-	Threshold int `json:"threshold"`
-	// Delay is measured in minutes.
-	Delay DurationMinutes `json:"delay,omitempty"`
 	// Repeat is measured in minutes.
 	Repeat DurationMinutes `json:"repeat"`
+}
+
+// AlertConfigDelay mixes in a configurable delay to AlertConfigBase.
+type AlertConfigDelay struct {
+	// Delay is measured in minutes.
+	Delay DurationMinutes `json:"delay,omitempty"`
+}
+
+// AlertConfigThreshold mixes in a configurable threshold to AlertConfigBase.
+type AlertConfigThreshold struct {
+	// Threshold is measured in mg/dL.
+	Threshold int `json:"threshold"`
+}
+
+// AlertConfigWithThreshold extends AlertConfigBase with a configurable trigger
+// threshold.
+type AlertConfigWithThreshold struct {
+	AlertConfigBase
+	AlertConfigThreshold
+}
+
+// AlertConfigWithDelay extends AlertConfigBase with a configurable delay.
+type AlertConfigWithDelay struct {
+	AlertConfigBase
+	AlertConfigDelay
+}
+
+// AlertConfigDeluxe extends AlertConfigBase with configurable delay and
+// threshold.
+type AlertConfigDeluxe struct {
+	AlertConfigBase
+	AlertConfigThreshold
+	AlertConfigDelay
 }
 
 // DurationMinutes reads a JSON integer and converts it to a time.Duration.

--- a/models/confirmation_test.go
+++ b/models/confirmation_test.go
@@ -1,6 +1,9 @@
 package models
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 const USERID = "1234-555"
 
@@ -122,4 +125,43 @@ func TestConfirmationKey(t *testing.T) {
 	if len(key) != 32 {
 		t.Fatal("The generated key should be 32 chars: ", len(key))
 	}
+}
+
+func TestDurationMinutes(s *testing.T) {
+	s.Run("parses 10", func(t *testing.T) {
+		d := DurationMinutes(0)
+		if err := d.UnmarshalJSON([]byte(`42`)); err != nil {
+			t.Fatalf("expected nil, got %+v", err)
+		}
+		if dur := d.Duration(); dur != 42*time.Minute {
+			t.Fatalf("expected 42 minutes, got %s", dur)
+		}
+	})
+	s.Run("parses 0", func(t *testing.T) {
+		d := DurationMinutes(3 * time.Minute)
+		if err := d.UnmarshalJSON([]byte(`0`)); err != nil {
+			t.Fatalf("expected nil, got %+v", err)
+		}
+		if dur := d.Duration(); dur != 0*time.Minute {
+			t.Fatalf("expected 0 minutes, got %s", dur)
+		}
+	})
+	s.Run("parses null as 0 minutes", func(t *testing.T) {
+		d := DurationMinutes(0)
+		if err := d.UnmarshalJSON([]byte(`null`)); err != nil {
+			t.Fatalf("expected nil, got %+v", err)
+		}
+		if dur := d.Duration(); dur != 0*time.Minute {
+			t.Fatalf("expected 0 minutes, got %s", dur)
+		}
+	})
+	s.Run("parses an empty value as 0 minutes", func(t *testing.T) {
+		d := DurationMinutes(0)
+		if err := d.UnmarshalJSON([]byte(``)); err != nil {
+			t.Fatalf("expected nil, got %+v", err)
+		}
+		if dur := d.Duration(); dur != 0*time.Minute {
+			t.Fatalf("expected 0 minutes, got %s", dur)
+		}
+	})
 }


### PR DESCRIPTION
This is a small PR that will be built upon with later PRs. Trying to keep things small.

AlertsConfig stores the initial configuration for notifications that can be included with a care team invitation.

Part of BACK-2500