### PR TITLE
[BACK-3375] Set confirmations userId if userId empty and email matches user before retrieving clinician or personal invites.

### DIFF
--- a/api/clinicianInvites.go
+++ b/api/clinicianInvites.go
@@ -221,7 +221,7 @@ func (a *Api) GetClinicianInvitations(res http.ResponseWriter, req *http.Request
 		// Populate userId of the confirmations for this user's userId if is not set. This will allow us to query by userId.
 		inviteType := models.TypeClinicianInvite
 		inviteStatus := models.StatusPending
-		if err := a.addUserIdsToEmptyPendingInvites(ctx, invitedUsr, inviteType, inviteStatus); err != nil {
+		if err := a.addUserIdsToUserlessInvites(ctx, invitedUsr, inviteType, inviteStatus); err != nil {
 			a.sendError(ctx, res, http.StatusInternalServerError, STATUS_ERR_UPDATING_CONFIRMATION, err)
 			return
 		}

--- a/api/clinicianInvites.go
+++ b/api/clinicianInvites.go
@@ -218,7 +218,15 @@ func (a *Api) GetClinicianInvitations(res http.ResponseWriter, req *http.Request
 			return
 		}
 
-		found, err := a.Store.FindConfirmations(ctx, &models.Confirmation{Email: invitedUsr.Emails[0], Type: models.TypeClinicianInvite}, models.StatusPending)
+		// Populate userId of the confirmations for this user's userId if is not set. This will allow us to query by userId.
+		inviteType := models.TypeClinicianInvite
+		inviteStatus := models.StatusPending
+		if err := a.addUserIdsToEmptyPendingInvites(ctx, invitedUsr, inviteType, inviteStatus); err != nil {
+			a.sendError(ctx, res, http.StatusInternalServerError, STATUS_ERR_UPDATING_CONFIRMATION, err)
+			return
+		}
+
+		found, err := a.Store.FindConfirmations(ctx, &models.Confirmation{UserId: invitedUsr.UserID, Type: inviteType}, inviteStatus)
 		if err != nil {
 			a.sendError(ctx, res, http.StatusInternalServerError, STATUS_ERR_FINDING_CONFIRMATION, err)
 			return

--- a/api/hydrophoneApi.go
+++ b/api/hydrophoneApi.go
@@ -76,6 +76,7 @@ const (
 	STATUS_ERR_SAVING_CONFIRMATION    = "Error saving the confirmation"
 	STATUS_ERR_SENDING_EMAIL          = "Error sending email"
 	STATUS_ERR_SETTING_PERMISSIONS    = "Error setting permissions"
+	STATUS_ERR_UPDATING_CONFIRMATION  = "Error updating confirmation"
 	STATUS_ERR_UPDATING_USER          = "Error updating user"
 	STATUS_ERR_VALIDATING_CONTEXT     = "Error validating the confirmation context"
 
@@ -509,6 +510,17 @@ func (a *Api) ensureIdSet(ctx context.Context, userId string, confirmations []*m
 			}
 		}
 	}
+}
+
+func (a *Api) addUserIdsToEmptyPendingInvites(ctx context.Context, user *shoreline.UserData, inviteType models.Type, inviteStatus models.Status) error {
+	opts := clients.FilterOpts{AllowEmptyUserID: true}
+	filter := &models.Confirmation{Email: user.Emails[0], UserId: "", Type: inviteType}
+	userlessConfirms, err := a.Store.FindConfirmationsWithOpts(ctx, filter, opts, inviteStatus)
+	if err != nil {
+		return err
+	}
+	a.ensureIdSet(ctx, user.UserID, userlessConfirms)
+	return nil
 }
 
 // Populate restrictions

--- a/api/hydrophoneApi.go
+++ b/api/hydrophoneApi.go
@@ -512,7 +512,7 @@ func (a *Api) ensureIdSet(ctx context.Context, userId string, confirmations []*m
 	}
 }
 
-func (a *Api) addUserIdsToEmptyPendingInvites(ctx context.Context, user *shoreline.UserData, inviteType models.Type, inviteStatus models.Status) error {
+func (a *Api) addUserIdsToUserlessInvites(ctx context.Context, user *shoreline.UserData, inviteType models.Type, inviteStatus models.Status) error {
 	opts := clients.FilterOpts{AllowEmptyUserID: true}
 	filter := &models.Confirmation{Email: user.Emails[0], UserId: "", Type: inviteType}
 	userlessConfirms, err := a.Store.FindConfirmationsWithOpts(ctx, filter, opts, inviteStatus)

--- a/api/invite.go
+++ b/api/invite.go
@@ -471,6 +471,9 @@ func (a *Api) SendInvite(res http.ResponseWriter, req *http.Request, vars map[st
 
 	invite.Email = ib.Email
 	if invitedUsr != nil {
+		// Not sure if need to another checkForDuplicateInvite here but by userId.
+		// I suppose it's unlikely person A would invite person B, B accepts, B changes their email,
+		// and then person A invites B under his new email.
 		invite.UserId = invitedUsr.UserID
 	}
 

--- a/api/invite.go
+++ b/api/invite.go
@@ -114,7 +114,7 @@ func (a *Api) GetReceivedInvitations(res http.ResponseWriter, req *http.Request,
 		// Populate userId of the confirmations for this user's userId if is not set. This will allow us to query by userId.
 		inviteType := models.TypeCareteamInvite
 		inviteStatus := models.StatusPending
-		if err := a.addUserIdsToEmptyPendingInvites(ctx, invitedUsr, inviteType, inviteStatus); err != nil {
+		if err := a.addUserIdsToUserlessInvites(ctx, invitedUsr, inviteType, inviteStatus); err != nil {
 			a.sendError(ctx, res, http.StatusInternalServerError, STATUS_ERR_UPDATING_CONFIRMATION, err)
 			return
 		}

--- a/clients/mockStoreClient.go
+++ b/clients/mockStoreClient.go
@@ -64,6 +64,21 @@ func (d *MockStoreClient) FindConfirmation(ctx context.Context, notification *mo
 	return notification, nil
 }
 
+func (d *MockStoreClient) FindConfirmationsWithOpts(ctx context.Context, confirmation *models.Confirmation, filter FilterOpts, statuses ...models.Status) (results []*models.Confirmation, err error) {
+	if d.doBad {
+		return nil, errors.New("FindConfirmationsWithOpts failure")
+	}
+	if d.returnNone {
+		return nil, nil
+	}
+
+	confirmation.Created = time.Now().AddDate(0, 0, -3) // created three days ago
+	confirmation.Context = []byte(`{"view":{}, "note":{}}`)
+	confirmation.UpdateStatus(statuses[0])
+
+	return []*models.Confirmation{confirmation}, nil
+}
+
 func (d *MockStoreClient) FindConfirmations(ctx context.Context, confirmation *models.Confirmation, statuses ...models.Status) (results []*models.Confirmation, err error) {
 	if d.doBad {
 		return nil, errors.New("FindConfirmation failure")

--- a/clients/mongoStoreClient.go
+++ b/clients/mongoStoreClient.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"context"
+	stdErrs "errors"
 	"fmt"
 	"regexp"
 
@@ -144,7 +145,7 @@ func (c *MongoStoreClient) FindConfirmation(ctx context.Context, confirmation *m
 
 	opts := options.FindOne().SetSort(bson.D{{Key: "created", Value: -1}})
 
-	if err = confirmationsCollection(c).FindOne(ctx, query, opts).Decode(&result); err != nil && err != mongo.ErrNoDocuments {
+	if err = confirmationsCollection(c).FindOne(ctx, query, opts).Decode(&result); err != nil && !stdErrs.Is(err, mongo.ErrNoDocuments) {
 		return result, err
 	}
 

--- a/clients/mongoStoreClient.go
+++ b/clients/mongoStoreClient.go
@@ -153,6 +153,10 @@ func (c *MongoStoreClient) FindConfirmation(ctx context.Context, confirmation *m
 
 // FindConfirmations - find and return existing confirmations
 func (c *MongoStoreClient) FindConfirmations(ctx context.Context, confirmation *models.Confirmation, statuses ...models.Status) (results []*models.Confirmation, err error) {
+	return c.FindConfirmationsWithOpts(ctx, confirmation, FilterOpts{}, statuses...)
+}
+
+func (c *MongoStoreClient) FindConfirmationsWithOpts(ctx context.Context, confirmation *models.Confirmation, extraFilters FilterOpts, statuses ...models.Status) (results []*models.Confirmation, err error) {
 	var query bson.M = bson.M{}
 
 	if confirmation.Email != "" {
@@ -171,7 +175,7 @@ func (c *MongoStoreClient) FindConfirmations(ctx context.Context, confirmation *
 	if confirmation.CreatorId != "" {
 		query["creatorId"] = confirmation.CreatorId
 	}
-	if confirmation.UserId != "" {
+	if confirmation.UserId != "" || extraFilters.AllowEmptyUserID {
 		query["userId"] = confirmation.UserId
 	}
 	if confirmation.ClinicId != "" {

--- a/clients/storeClient.go
+++ b/clients/storeClient.go
@@ -6,10 +6,17 @@ import (
 	"github.com/tidepool-org/hydrophone/models"
 )
 
+// FilterOpts allows further filtering options of Confirmation retrieval for more specific use cases.
+// The zero value is fine for the "default" case of filtering on the logical AND of non empty fields.
+type FilterOpts struct {
+	AllowEmptyUserID bool // If true, then specifically query for an empty string userId instead of not including in the query.
+}
+
 type StoreClient interface {
 	Ping(ctx context.Context) error
 	UpsertConfirmation(ctx context.Context, confirmation *models.Confirmation) error
 	FindConfirmations(ctx context.Context, confirmation *models.Confirmation, statuses ...models.Status) (results []*models.Confirmation, err error)
+	FindConfirmationsWithOpts(ctx context.Context, confirmation *models.Confirmation, opts FilterOpts, statuses ...models.Status) (results []*models.Confirmation, err error)
 	FindConfirmation(ctx context.Context, confirmation *models.Confirmation) (result *models.Confirmation, err error)
 	RemoveConfirmation(ctx context.Context, confirmation *models.Confirmation) error
 	RemoveConfirmationsForUser(ctx context.Context, userId string) error


### PR DESCRIPTION
This allows us to associate/retrieve confirmations by userId instead of email.